### PR TITLE
Make hibernate support  java.time (java 8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hibernate-entitymanager</artifactId>
+                    <groupId>org.hibernate</groupId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -48,6 +54,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.2.9.Final</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>


### PR DESCRIPTION
I've noticed that JPA will save java.time (java 8) data type as a `bytea` not as Postgres `Date` type
```
 Column  |          Type          | Modifiers 
---------+------------------------+-----------
 nik     | character varying(255) | not null
 date    | bytea                  | 
 tap_in  | bytea                  | 
 tap_out | bytea                  | 
```

This pull request will make it possible to save java.time data type as Postgres data type. Like this:
```
 Column  |          Type          | Modifiers 
---------+------------------------+-----------
 nik     | character varying(255) | not null
 date    | date                   | 
 tap_in  | time without time zone | 
 tap_out | time without time zone | 
```

review anyone?