### PR TITLE
Add swagger support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,16 @@
         <version>1.3</version>
         <scope>test</scope>
       </dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>2.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.7.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/blibli/future/config/SwaggerConfiguration.java
+++ b/src/main/java/com/blibli/future/config/SwaggerConfiguration.java
@@ -1,0 +1,22 @@
+package com.blibli.future.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.blibli.future.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/src/main/java/com/blibli/future/config/WebConfig.java
+++ b/src/main/java/com/blibli/future/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.blibli.future.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 @Configuration
@@ -13,5 +14,15 @@ public class WebConfig extends WebMvcConfigurerAdapter {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost")
                 .allowedMethods("GET", "PUT", "POST", "DELETE");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("swagger-ui.html")
+                .addResourceLocations("classpath:/META-INF/resources/");
+
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
+
     }
 }


### PR DESCRIPTION
In my confusion on merging Back End and Front End, rather than looking on our (non-updated) API Spec, using Swagger is a lot easier (and more human readable) for me.

This PR will enable swagger support. You can use it by navigating to `/swagger-ui.html` on your browser. Try it, Guys.