### PR TITLE
Cors and security security

### DIFF
--- a/src/main/java/com/blibli/future/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/blibli/future/config/WebSecurityConfiguration.java
@@ -34,7 +34,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable()
+        http.csrf().disable().cors().and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeRequests()
                 .antMatchers("/shift").hasRole("ADMIN")


### PR DESCRIPTION
This PR enable CORS for Spring security.

Previously, CORS works fine without Spring security, but after Spring Security is integrated, Spring Security don't allow any Cross Origin Request.